### PR TITLE
v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - `ReleasePackerCommandUploadReleaseBundle`:
   - Added `byURL` and `byGSC` constructors.
 
+- `ReleaseBundle`:
+  - Added `contentType`.
 
 - gcloud: ^0.8.11
 - googleapis_auth: ^1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 - New `ReleasePackerCommandGCS`.
 - `ReleasePackerCommandUploadReleaseBundle`:
   - Added `byURL` and `byGSC` constructors.
-
 - `ReleaseBundle`:
   - Added `contentType`.
+
+- `bin/release_packer`
+  - New option `--allow-env`: allow config properties from environment variables.
 
 - gcloud: ^0.8.11
 - googleapis_auth: ^1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.1.6
+
+- New `ReleasePackerCommandGCS`.
+- `ReleasePackerCommandUploadReleaseBundle`:
+  - Added `byURL` and `byGSC` constructors.
+
+
+- gcloud: ^0.8.11
+- googleapis_auth: ^1.4.1
+- data_serializer: ^1.0.12
+- ascii_art_tree: ^1.0.6
+- archive: ^3.4.9
+- test: ^1.24.9
+- dependency_validator: ^3.2.3
+- coverage: ^1.7.1
+
 ## 1.1.5
 
 - Improved console output of CLI tools.

--- a/bin/release_packer.dart
+++ b/bin/release_packer.dart
@@ -38,6 +38,7 @@ void main(List<String> args) async {
   args = args.toList();
 
   var releasePackerJsonPath = args.removeAt(0);
+  var allowEnv = args.remove('--allow-env');
   var properties = parseProperties(args);
 
   var cmd = args.removeAt(0).toLowerCase();
@@ -45,8 +46,11 @@ void main(List<String> args) async {
   print('»  Current directory: ${Directory.current.path}');
 
   print('»  Loading `ReleasePacker` from: $releasePackerJsonPath');
-  var releasePacker =
-      ReleasePacker.fromFilePath(releasePackerJsonPath, properties: properties);
+  var releasePacker = ReleasePacker.fromFilePath(
+    releasePackerJsonPath,
+    properties: properties,
+    allowPropertiesFromEnv: allowEnv,
+  );
 
   if (cmd == 'info') {
     var sourcePath = args.isNotEmpty ? args[0] : './';
@@ -133,7 +137,7 @@ Future<ReleaseBundleZip> _buildReleaseBundle(
   print('\n»»  Generating release bundle...\n');
 
   print(
-      '» Building release from `$sourcePath`${releasesPath != null ? ' to `$releasesPath`' : ''}');
+      '»  Building release from `$sourcePath`${releasesPath != null ? ' to `$releasesPath`' : ''}');
 
   var platform = ReleasePlatform.platform;
 

--- a/lib/release_packer_gcs.dart
+++ b/lib/release_packer_gcs.dart
@@ -1,0 +1,5 @@
+/// Release Updater Packer Library + GCS support.
+library release_updater.packer.gcs;
+
+export 'release_packer.dart';
+export 'src/release_packer_gcs.dart';

--- a/lib/src/release_packer.dart
+++ b/lib/src/release_packer.dart
@@ -750,9 +750,9 @@ class ReleasePackerCommandURL extends ReleasePackerCommand {
 }
 
 class ReleasePackerCommandUploadReleaseBundle extends ReleasePackerCommand {
-  late final ReleasePackerCommand _uploadCommand;
+  final ReleasePackerCommand uploadCommand;
 
-  ReleasePackerCommandUploadReleaseBundle._(this._uploadCommand);
+  ReleasePackerCommandUploadReleaseBundle._(this.uploadCommand);
 
   factory ReleasePackerCommandUploadReleaseBundle.byURL(String url,
       {Map<String, Object?>? parameters,
@@ -803,11 +803,13 @@ class ReleasePackerCommandUploadReleaseBundle extends ReleasePackerCommand {
 
     if (json is Map) {
       var map = json.asJsonMap;
+
       file = map.get('file');
       release = map.get('release');
 
-      if (json.containsKey('gcs')) {
-        var cmd = ReleasePackerCommandGCS.fromJson(json);
+      var gcs = map.get<Map>('gcs');
+      if (gcs != null) {
+        var cmd = ReleasePackerCommandGCS.fromJson(gcs);
 
         return ReleasePackerCommandUploadReleaseBundle.byGCS(
             cmd.project, cmd.bucket,
@@ -830,7 +832,7 @@ class ReleasePackerCommandUploadReleaseBundle extends ReleasePackerCommand {
   @override
   FutureOr<bool> execute(ReleasePacker releasePacker, Directory rootDirectory,
       {ReleaseBundle? releaseBundle}) {
-    return _uploadCommand.execute(releasePacker, rootDirectory,
+    return uploadCommand.execute(releasePacker, rootDirectory,
         releaseBundle: releaseBundle);
   }
 }

--- a/lib/src/release_packer.dart
+++ b/lib/src/release_packer.dart
@@ -32,9 +32,14 @@ class ReleasePacker {
       this.configDirectory})
       : properties = properties ?? <String, String>{};
 
-  factory ReleasePacker.fromJson(Map<String, Object?> json,
-      {Map<String, String>? properties, Directory? rootDirectory}) {
-    json = resolveJsonMapProperties(json, properties);
+  factory ReleasePacker.fromJson(
+    Map<String, Object?> json, {
+    Map<String, String>? properties,
+    Directory? rootDirectory,
+    bool allowPropertiesFromEnv = false,
+  }) {
+    json = resolveJsonMapProperties(json, properties,
+        allowEnv: allowPropertiesFromEnv);
 
     var name = json.get<String>('name') ?? 'app';
     var versionStr = json.get<String>('version');
@@ -65,21 +70,33 @@ class ReleasePacker {
         configDirectory: rootDirectory);
   }
 
-  factory ReleasePacker.fromFilePath(String filePath,
-      {Map<String, String>? properties, Directory? rootDirectory}) {
+  factory ReleasePacker.fromFilePath(
+    String filePath, {
+    Map<String, String>? properties,
+    Directory? rootDirectory,
+    bool allowPropertiesFromEnv = false,
+  }) {
     var file = _toFile(filePath, rootDirectory);
     return ReleasePacker.fromFile(file,
-        properties: properties, rootDirectory: rootDirectory);
+        properties: properties,
+        rootDirectory: rootDirectory,
+        allowPropertiesFromEnv: allowPropertiesFromEnv);
   }
 
-  factory ReleasePacker.fromFile(File file,
-      {Map<String, String>? properties, Directory? rootDirectory}) {
+  factory ReleasePacker.fromFile(
+    File file, {
+    Map<String, String>? properties,
+    Directory? rootDirectory,
+    bool allowPropertiesFromEnv = false,
+  }) {
     var json = _readFile(file, expected: true);
     if (json == null) {
       throw StateError("Can't read JSON from file: $file");
     }
     return ReleasePacker.fromJson(json,
-        properties: properties, rootDirectory: rootDirectory ?? file.parent);
+        properties: properties,
+        rootDirectory: rootDirectory ?? file.parent,
+        allowPropertiesFromEnv: allowPropertiesFromEnv);
   }
 
   static File _toFile(String filePath, Directory? rootDirectory) {

--- a/lib/src/release_packer_gcs.dart
+++ b/lib/src/release_packer_gcs.dart
@@ -164,6 +164,7 @@ class ReleasePackerCommandGCS extends ReleasePackerCommand {
     }
 
     print('   »  Parsing Google Cloud Storage credential...');
+
     var client = await createGCSClient(credential);
 
     print(

--- a/lib/src/release_packer_gcs.dart
+++ b/lib/src/release_packer_gcs.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+import 'dart:convert' as dart_convert;
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer_io.dart';
+import 'package:gcloud/storage.dart' as gcs;
+import 'package:googleapis_auth/auth_io.dart' as auth;
+
+import 'release_packer.dart';
+import 'release_updater_bundle.dart';
+import 'release_updater_config.dart';
+
+class ReleasePackerCommandGCS extends ReleasePackerCommand {
+  final String project;
+  final String bucket;
+  final Object credential;
+
+  final Map<String, Object?>? parameters;
+  final Object? body;
+
+  ReleasePackerCommandGCS(this.project, this.bucket,
+      {required this.credential, this.parameters, this.body}) {
+    if (project.isEmpty) throw ArgumentError("Empty project!");
+    if (bucket.isEmpty) throw ArgumentError("Empty bucket!");
+  }
+
+  factory ReleasePackerCommandGCS.fromJson(Map json) {
+    var map = json.asJsonMap;
+
+    var project =
+        map.get<String>('project') ?? (throw ArgumentError.notNull('project'));
+    var bucket =
+        map.get<String>('bucket') ?? (throw ArgumentError.notNull('bucket'));
+    var credential =
+        map.get('credential') ?? (throw ArgumentError.notNull('credential'));
+
+    var parameters = map.get<Map>('parameters');
+    var body = map.get('body');
+
+    return ReleasePackerCommandGCS(project, bucket,
+        credential: credential, parameters: parameters?.asJsonMap, body: body);
+  }
+
+  static Future<auth.AutoRefreshingAuthClient> createGCSClient(
+      Object credential) async {
+    if (credential is String) {
+      var credentialLC = credential.toLowerCase();
+      if (credentialLC == 'metadata' || credentialLC == 'metadata.server') {
+        return auth.clientViaMetadataServer();
+      }
+    }
+
+    final accountCredentials =
+        auth.ServiceAccountCredentials.fromJson(credential);
+
+    try {
+      var client = await auth.clientViaServiceAccount(
+          accountCredentials, gcs.Storage.SCOPES);
+      return client;
+    } catch (e) {
+      throw StateError("Error creating GCP client: $e");
+    }
+  }
+
+  @override
+  Future<bool> execute(ReleasePacker releasePacker, Directory rootDirectory,
+      {ReleaseBundle? releaseBundle}) async {
+    String? file;
+    String? release;
+    Object? body;
+
+    if (this.body == '%RELEASE_BUNDLE%') {
+      if (releaseBundle == null) {
+        print('  ▒  Release bundle not provided for body: $this');
+        return false;
+      } else {
+        print('   »  Using `ReleaseBundle` as body.');
+
+        file = parameters?['file'] as String?;
+        if (file != null) {
+          var release = releaseBundle.release;
+          var fileFormatted = ReleaseBundle.formatReleaseBundleFile(
+              file, release.name, release.version, release.platform);
+          file = fileFormatted;
+
+          print('   »  Parameter `file`: $fileFormatted');
+        }
+
+        release = parameters?['release'] as String?;
+        if (release != null && release.toLowerCase() == '%release%') {
+          release = releaseBundle.release.toString();
+          release = release;
+        }
+      }
+      body = await releaseBundle.toBytes();
+    } else {
+      file = parameters?['file'] as String?;
+      release = parameters?['release'] as String?;
+      body = this.body;
+    }
+
+    if (file == null) {
+      throw ArgumentError.notNull("file");
+    }
+
+    if (body == null) {
+      throw ArgumentError.notNull("body");
+    }
+
+    var contentType = parameters?['contentType'] as String?;
+    contentType ??= 'application/octet-stream';
+
+    Uint8List bodyBytes;
+    if (body is String) {
+      bodyBytes = dart_convert.utf8.encode(body);
+    } else if (body is List<int>) {
+      bodyBytes = body.asUint8List;
+    } else {
+      throw ArgumentError("Invalid body type: ${body.runtimeType}");
+    }
+
+    gcs.ObjectMetadata? metadata;
+    if (release != null) {
+      metadata = gcs.ObjectMetadata(
+        contentType: contentType,
+        custom: {
+          'release': release,
+        },
+      );
+    }
+
+    print('   »  Parsing Google Cloud Storage credential...');
+    var client = await createGCSClient(credential);
+
+    print(
+        '   »  Uploading to Google Cloud Storage> project: $project ; bucket: ${this.bucket}');
+
+    var storage = gcs.Storage(client, project);
+    var bucket = storage.bucket(this.bucket);
+
+    var objInfo = await bucket.writeBytes(
+      file,
+      bodyBytes,
+      contentType: contentType,
+      metadata: metadata,
+    );
+
+    var ok = objInfo.length == bodyBytes.length;
+
+    print('   »  GCS response> ${ok ? 'Ok' : 'Faul'}');
+
+    return ok;
+  }
+
+  @override
+  String toString() {
+    return '$runtimeType{ project: $project, bucket: $bucket, parameters: $parameters, credential: $credential, body: $body }';
+  }
+}

--- a/lib/src/release_updater_base.dart
+++ b/lib/src/release_updater_base.dart
@@ -2,12 +2,13 @@ import 'dart:async';
 import 'dart:convert' as dart_convert;
 import 'dart:typed_data';
 
+import 'package:data_serializer/data_serializer_io.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
 
+import 'release_updater_bundle.dart';
 import 'release_updater_provider.dart';
 import 'release_updater_storage.dart';
 import 'release_updater_utils.dart';
-import 'release_updater_bundle.dart';
 
 abstract class Copiable<T> {
   /// Returns a copy of this instance.
@@ -25,7 +26,7 @@ typedef OnRelease = void Function(Release release);
 /// A [Release] updater from [releaseProvider] to [storage].
 class ReleaseUpdater implements Copiable<ReleaseUpdater>, Spawnable {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.1.5';
+  static const String VERSION = '1.1.6';
 
   /// The [Release] storage.
   final ReleaseStorage storage;
@@ -391,9 +392,8 @@ class ReleaseFile implements Comparable<ReleaseFile> {
     }
 
     var s = data.toString();
-    var encoded = dart_convert.utf8.encode(s);
-    return UnmodifiableUint8ListView(
-        encoded is Uint8List ? encoded : Uint8List.fromList(encoded));
+    var encoded = dart_convert.utf8.encode(s).asUint8List;
+    return UnmodifiableUint8ListView(encoded);
   }
 
   FutureOr<int> get length {

--- a/lib/src/release_updater_bundle.dart
+++ b/lib/src/release_updater_bundle.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:convert' as dart_convert;
 import 'dart:typed_data';
-import 'package:ascii_art_tree/ascii_art_tree.dart';
 
 import 'package:archive/archive.dart';
+import 'package:ascii_art_tree/ascii_art_tree.dart';
 import 'package:base_codecs/base_codecs.dart';
 import 'package:collection/collection.dart';
+import 'package:data_serializer/data_serializer_io.dart';
 
 import 'release_updater_base.dart';
 
@@ -266,8 +267,8 @@ class ReleaseManifest {
   }
 
   Uint8List toJsonEncodedBytes() {
-    var bs = dart_convert.utf8.encode(toJsonEncoded());
-    return bs is Uint8List ? bs : Uint8List.fromList(bs);
+    var bs = dart_convert.utf8.encode(toJsonEncoded()).asUint8List;
+    return bs;
   }
 
   String toJsonEncoded() {

--- a/lib/src/release_updater_bundle.dart
+++ b/lib/src/release_updater_bundle.dart
@@ -22,6 +22,9 @@ abstract class ReleaseBundle {
   /// Converts this bundle to bytes.
   FutureOr<Uint8List> toBytes();
 
+  /// Returns the MIME-Type of [toBytes].
+  String get contentType;
+
   static const String defaultReleasesBundleFileFormat =
       '%NAME%-%VER%%[-]PLATFORM%.zip';
 
@@ -182,6 +185,9 @@ class ReleaseBundleZip extends ReleaseBundle {
 
     return releaseFile;
   }
+
+  @override
+  String get contentType => 'application/zip';
 
   @override
   FutureOr<Uint8List> toBytes() => zipBytes;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: release_updater
 description: A simple way to automatically update release/installation files in a local directory.
-version: 1.1.5
+version: 1.1.6
 homepage: https://github.com/gmpassos/release_updater
 
 environment:
@@ -14,25 +14,28 @@ executables:
 
 
 dependencies:
-  archive: ^3.3.8
+  data_serializer: ^1.0.12
+  ascii_art_tree: ^1.0.6
   mercury_client: ^2.2.0
-  path: ^1.8.3
-  pub_semver: ^2.1.4
   shelf: ^1.4.1
   shelf_static: ^1.1.2
   shelf_gzip: ^4.0.1
+  gcloud: ^0.8.11
+  googleapis_auth: ^1.4.1
   crypto: ^3.0.3
+  path: ^1.8.3
+  pub_semver: ^2.1.4
   base_codecs: ^1.0.1
-  data_serializer: ^1.0.10
+  archive: ^3.4.9
   collection: ^1.17.1
   yaml: ^3.1.2
-  ascii_art_tree: ^1.0.4
+
 
 dev_dependencies:
   lints: ^2.1.1
-  test: ^1.24.1
-  dependency_validator: ^3.2.2
-  coverage: ^1.6.3
+  test: ^1.24.9
+  dependency_validator: ^3.2.3
+  coverage: ^1.7.1
   pubspec: ^2.3.0
 
 #dependency_overrides:

--- a/test/release_packer_gcs_test.dart
+++ b/test/release_packer_gcs_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+import 'package:path/path.dart' as pack_path;
 import 'package:release_updater/release_packer_gcs.dart';
 //import 'package:pub_semver/pub_semver.dart' ;
 import 'package:release_updater/release_updater.dart';
@@ -78,7 +79,8 @@ void main() {
             equals((
               bodyBytes: bundleBytes,
               contentType: 'application/bundle',
-              filePath: 'foo-app/releases/foo-app-1.0.0.zip',
+              filePath:
+                  pack_path.normalize('foo-app/releases/foo-app-1.0.0.zip'),
               release: 'foo-app/1.0.0',
             )));
       }

--- a/test/release_packer_gcs_test.dart
+++ b/test/release_packer_gcs_test.dart
@@ -1,0 +1,60 @@
+@TestOn('vm')
+import 'package:release_updater/src/release_packer.dart';
+import 'package:release_updater/src/release_packer_gcs.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ReleasePacker (GCS)', () {
+    test('ReleasePackerCommandGCS', () async {
+      {
+        var cmd = ReleasePackerCommandGCS.fromJson({
+          "project": "project1",
+          "bucket": "files-bucket",
+          "credential": 'metadata.server',
+          "parameters": {"file": 'release-x.zip'}
+        });
+
+        expect(cmd.project, equals('project1'));
+        expect(cmd.bucket, equals('files-bucket'));
+        expect(cmd.credential, isNotNull);
+        expect(cmd.parameters, equals({"file": 'release-x.zip'}));
+      }
+    });
+
+    test('ReleasePackerCommandUploadReleaseBundle', () async {
+      var cmd = ReleasePackerCommand.from({
+        "upload_release": {
+          "gcs": {
+            "project": "project-x",
+            "bucket": "project-releases",
+            "credential": {
+              "type": "service_account",
+              "project_id": "project-x",
+              "private_key_id": "%GCS_PRIVATE_KEY_ID%",
+              "private_key": "%GCS_PRIVATE_KEY%",
+              "client_email": "%GCS_CLIENT_EMAIL%",
+              "client_id": "%GCS_CLIENT_ID%",
+              "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+              "token_uri": "https://oauth2.googleapis.com/token",
+              "auth_provider_x509_cert_url":
+                  "https://www.googleapis.com/oauth2/v1/certs",
+              "client_x509_cert_url": "%GCS_CERT_URL%"
+            }
+          }
+        }
+      });
+
+      expect(cmd, isA<ReleasePackerCommandUploadReleaseBundle>());
+
+      var cmdBundle = cmd as ReleasePackerCommandUploadReleaseBundle;
+
+      expect(cmdBundle.uploadCommand, isA<ReleasePackerCommandGCS>());
+
+      var cmdGCS = cmdBundle.uploadCommand as ReleasePackerCommandGCS;
+
+      expect(cmdGCS.project, equals('project-x'));
+      expect(cmdGCS.bucket, equals('project-releases'));
+      expect(cmdGCS.credential, isA<Map>());
+    });
+  });
+}

--- a/test/release_updater_config_test.dart
+++ b/test/release_updater_config_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:collection/collection.dart';
 import 'package:release_updater/src/release_updater_config.dart';
 import 'package:test/test.dart';
 
@@ -45,6 +48,53 @@ void main() {
 
       expect(args, equals(['file']));
       expect(config, equals({'k1': 'v1', 'k2': 'v2'}));
+    });
+
+    test('resolveJsonProperties', () {
+      expect(
+          resolveJsonProperties(
+            {
+              'params': [
+                {'id': '%FOO%'},
+              ]
+            },
+            {'FOO': 'bar'},
+          ),
+          equals({
+            'params': [
+              {'id': 'bar'},
+            ]
+          }));
+    });
+
+    test('resolveJsonProperties (allowEnv)', () {
+      var envEntry = Platform.environment.entries
+          .firstWhereOrNull((e) => e.key.length >= 2 && e.value.isNotEmpty);
+
+      var envKey = envEntry?.key ?? 'ENVx';
+      var envVal = envEntry?.value ?? 'VALy';
+
+      var properties = envEntry != null ? null : {envKey: envVal};
+
+      print("-- envKey: $envKey");
+      print("-- envVal: $envVal");
+      print("-- properties: $properties");
+
+      expect(
+          resolveJsonProperties(
+            {
+              'params': [
+                {'id': '%$envKey%'},
+              ]
+            },
+            properties,
+            allowEnv: true,
+          ),
+          equals({
+            'params': [
+              {'id': envVal},
+            ]
+          }));
     });
   });
 }

--- a/test/release_updater_test.dart
+++ b/test/release_updater_test.dart
@@ -377,6 +377,9 @@ class _MyReleaseBundle extends ReleaseBundle {
   FutureOr<Set<ReleaseFile>> get files => _files.toSet();
 
   @override
+  String get contentType => 'application/octet-stream';
+
+  @override
   FutureOr<Uint8List> toBytes() {
     throw UnimplementedError();
   }


### PR DESCRIPTION
- New `ReleasePackerCommandGCS`.
- `ReleasePackerCommandUploadReleaseBundle`:
  - Added `byURL` and `byGSC` constructors.

- gcloud: ^0.8.11
- googleapis_auth: ^1.4.1
- data_serializer: ^1.0.12
- ascii_art_tree: ^1.0.6
- archive: ^3.4.9
- test: ^1.24.9
- dependency_validator: ^3.2.3
- coverage: ^1.7.1